### PR TITLE
Fix package installation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist/jspdf.customfonts.debug.js",
     "dist/jspdf.customfonts.min.js",
+    "makeFonts.js",
     "README.md"
   ],
   "bin": {


### PR DESCRIPTION
Added `makeFonts.js` to the list of package files. Without it installation fails:

```
npm ERR! enoent ENOENT: no such file or directory, chmod 'node_modules/jspdf-customfonts/makeFonts.js'
npm ERR! enoent This is related to npm not being able to find a file.
```